### PR TITLE
Test as_json configuration

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,7 @@
 class ApplicationController < ActionController::Base
+  
+  def users
+    users = User.all
+    render(:plain => users.as_json)
+  end
 end

--- a/config/initializers/wrap_parameters.rb
+++ b/config/initializers/wrap_parameters.rb
@@ -9,6 +9,6 @@ ActiveSupport.on_load(:action_controller) do
 end
 
 # To enable root element in JSON for ActiveRecord objects.
-# ActiveSupport.on_load(:active_record) do
-#   self.include_root_in_json = true
-# end
+ActiveSupport.on_load(:active_record) do
+  self.include_root_in_json = true
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,7 @@
 Rails.application.routes.draw do
+  
+  match("/users", {:controller => "application", :action => "users", :via => "get"})
+  
   devise_for :admin_users, ActiveAdmin::Devise.config
   ActiveAdmin.routes(self)
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html


### PR DESCRIPTION
For firstdraft/appdev_template#73

This branch has one route defined for `/users` that uses the `as_json` method.

I've configured 
```
ActiveSupport.on_load(:active_record) do
  self.include_root_in_json = true
end
```

which I _think_ is what the goal is.